### PR TITLE
Add persona profile fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,26 @@ firebase deploy --only functions
 This deploys the Express app as `api` Cloud Function. After deployment you can access the endpoints via:
 
 - `POST https://<region>-<project>.cloudfunctions.net/api/createQR`
-  - Body: character fields. Returns `{ uuid, qrCode }` where `qrCode` is a base64 encoded PNG image.
-- `GET  https://<region>-<project>.cloudfunctions.net/api/loadQR/{uuid}`
+  - Body: object profile fields. Returns `{ personaId, qrUrl }` where `qrUrl` is a signed PNG URL.
+- `GET  https://<region>-<project>.cloudfunctions.net/api/loadQR/{personaId}`
 
 Make sure your Firestore database is in native mode.
+
+## Profile Data Fields
+
+Profiles created via `createQR` contain the following properties:
+
+- `personaId` – unique identifier stored as the Firestore document ID.
+- `name` – the nickname of the object.
+- `objectType` – type of object created (e.g. "머그컵").
+- `location` – where the object is kept.
+- `duration` – how long the user has had the object.
+- `purpose` – description of what role the object plays.
+- `humorStyle` – selected humor or personality tone.
+- `greeting` – greeting shown on the completion screen.
+- `tags` – list of personality traits.
+- `finalPersonality` – object containing `introversion`, `warmth`, and `competence` values.
+- `photoUrl` – optional image URL.
+- `createdBy`, `createdAt` – creator info and timestamp.
+- `totalInteractions`, `uniqueUsers` – usage analytics counters.
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,18 @@ app.post(
   [
     // 입력값 검증
     body('name').isString().notEmpty(),
+    body('objectType').isString().optional(),
+    body('location').isString().optional(),
+    body('duration').isString().optional(),
+    body('purpose').isString().optional(),
+    body('humorStyle').isString().optional(),
     body('greeting').isString().optional(),
+    body('tags').isArray().optional(),
+    body('finalPersonality').optional().isObject(),
+    body('finalPersonality.introversion').optional().isNumeric(),
+    body('finalPersonality.warmth').optional().isNumeric(),
+    body('finalPersonality.competence').optional().isNumeric(),
+    body('photoUrl').isString().optional(),
   ],
   async (req, res) => {
     const errors = validationResult(req);
@@ -61,8 +72,21 @@ app.post(
       const id = uuidv4();
       // 데이터 모델 확장 및 기본값 설정
       const profile = {
+        personaId: id,
         name: data.name,
+        objectType: data.objectType || '',
+        location: data.location || '',
+        duration: data.duration || '',
+        purpose: data.purpose || '',
+        humorStyle: data.humorStyle || '',
         greeting: data.greeting || '',
+        tags: Array.isArray(data.tags) ? data.tags : [],
+        finalPersonality: {
+          introversion: data.finalPersonality?.introversion ?? 0,
+          warmth: data.finalPersonality?.warmth ?? 0,
+          competence: data.finalPersonality?.competence ?? 0,
+        },
+        photoUrl: data.photoUrl || '',
         createdBy: req.user.uid,        // 생성자 정보 기록
         totalInteractions: 0,           // 대화 횟수 초기화
         uniqueUsers: 0,                 // 고유 사용자 수 초기화
@@ -77,7 +101,7 @@ app.post(
       await file.save(qrBuffer, { contentType: 'image/png' });
       const [url] = await file.getSignedUrl({ action: 'read', expires: '03-01-2500' });
 
-      res.status(200).json({ uuid: id, qrUrl: url });
+      res.status(200).json({ personaId: id, qrUrl: url });
     } catch (err) {
       functions.logger.error('createQR 실패', err); // 에러 로깅
       res.status(500).json({ error: 'Failed to create QR profile' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "express-validator": "^7.2.1",
         "firebase-admin": "^11.8.0",
         "firebase-functions": "^4.4.1",
         "qrcode": "^1.5.4",
@@ -1314,6 +1315,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2203,8 +2217,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3445,6 +3458,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-validator": "^7.2.1",
     "firebase-admin": "^11.8.0",
     "firebase-functions": "^4.4.1",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Summary
- support additional profile fields in `createQR`
- validate new fields
- document fields in README
- add `express-validator` dependency

## Testing
- `node -c index.js`
- `npm start` *(fails: Cannot find module './serviceAccountKey.json')*

------
https://chatgpt.com/codex/tasks/task_e_6847cc168f50833193261d91475178b1